### PR TITLE
Feature/#9 docker cicd

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -1,0 +1,111 @@
+# dev branch 변경된 경우 dev 서버로 반영
+name: dev-publish
+
+on:
+  workflow_dispatch:
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 21
+      uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+
+    - name: Build with Gradle
+      run: ./gradlew build
+
+    - name: Docker image build and push
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+        tags: latest
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout dev
+      uses: actions/checkout@v4
+  
+    - name: Connect to EC2 and install docker 
+      env:
+        EC2_HOST: ${{ secrets.EC2_HOST }}
+        EC2_USER: ${{ secrets.EC2_USERNAME }}
+        EC2_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      run: |
+        echo "$EC2_SSH_KEY" > ec2_key.pem
+        chmod 400 ec2_key.pem
+        ssh -i ec2_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST '
+          # sudo 설치
+          if ! command -v sudo &> /dev/null; then
+            apt update && apt install -y sudo
+          fi
+          
+          # Docker 설치
+          if ! command -v docker &> /dev/null
+          then
+            sudo apt-get update
+            sudo apt-get install ca-certificates curl
+            sudo install -m 0755 -d /etc/apt/keyrings
+            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+            sudo chmod a+r /etc/apt/keyrings/docker.asc
+            
+            # Add the repository to Apt sources:
+            echo \
+              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+              $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+              sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+            sudo apt-get update
+            
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  
+            # Docker 서비스 시작 및 활성화
+            sudo systemctl start docker
+            sudo systemctl enable docker
+    
+            # Docker 버전 확인
+            docker --version
+            docker compose version
+          else
+            echo "Docker already installed"
+            docker --version
+            docker compose version
+          fi
+        '  
+        
+    - name: Copy docker-compose file to EC2
+      env:
+        EC2_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+        EC2_HOST: ${{ secrets.EC2_HOST }}
+        EC2_USER: ${{ secrets.EC2_USERNAME }}
+      run: |
+        scp -o StrictHostKeyChecking=no -i ec2_key.pem docker-compose.yml ${EC2_USER}@${EC2_HOST}:~/
+        scp -o StrictHostKeyChecking=no -i ec2_key.pem docker-compose.override.yml ${EC2_USER}@${EC2_HOST}:~/
+
+
+    - name: pull docker and run server
+      env:
+        EC2_HOST: ${{ secrets.EC2_HOST }}
+        EC2_USER: ${{ secrets.EC2_USERNAME }}
+        EC2_SSH_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      run: |
+        ssh -i ec2_key.pem -o StrictHostKeyChecking=no $EC2_USER@$EC2_HOST '
+          # 명령어 실행
+          sudo docker rm -f $(sudo docker compose ps -qa)
+          sudo docker pull ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}
+          sudo docker compose up -d
+          sudo docker image prune -f
+        '
+        
+  

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/NongDam-backend/.gitignore
+++ b/NongDam-backend/.gitignore
@@ -5,6 +5,11 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### env ###
+.env
+.env.prod
+.env.dev
+
 ### STS ###
 .apt_generated
 .classpath

--- a/NongDam-backend/Dockerfile
+++ b/NongDam-backend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM gradle:8.5-jdk21 AS build
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+COPY src ./src
+RUN gradle build --no-daemon
+
+# Run stage
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY --from=build /app/build/libs/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/NongDam-backend/docker-compose.override.yml
+++ b/NongDam-backend/docker-compose.override.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+  spot:
+    image: wonjun0120/nongdam:latest
+    env_file:
+      - .env.dev
+    depends_on:
+      - db
+
+  db:
+    image: mysql:8.0
+    environment:
+      - MYSQL_ROOT_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
+      - MYSQL_DATABASE=nongdam
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:

--- a/NongDam-backend/docker-compose.prod.yml
+++ b/NongDam-backend/docker-compose.prod.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+
+services:
+  app:
+    image: wonjun0120/nongdam:latest
+    environment:
+      - .env.prod

--- a/NongDam-backend/docker-compose.yml
+++ b/NongDam-backend/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  spot:
+    container_name: nongdam-server
+    restart: always
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9

## 📝작업 내용

> 도커 및 ec2 세팅, github actions 세팅

## 💬리뷰 요구사항(선택)

> github actions의 경우 메인 브렌치(dev)에 있어야 동작이 가능하다고 합니다.
그래서 이전 actions 테스트해보느라 dev에서 작업했습니다. 미리 말씀드렸어야했는데 죄송합니다..
작업하다보니 Dockerfile이 있어야 actions가 동작하여 해당 브랜치 머지 후 dev 브랜치에서 세팅 이어가려하는데 괜찮을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new GitHub Actions workflow for automated building and deployment of the application to an EC2 instance.
	- Added new Docker Compose configurations for development and production environments, including services for the application and database.
  
- **Bug Fixes**
	- Updated `.gitignore` files to exclude environment configuration files and local development artifacts.

- **Chores**
	- Created a multi-stage Dockerfile for optimized application building and runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->